### PR TITLE
fix: skip nix on darwin only when nix-darwin is installed by XYenon

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -274,6 +274,16 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
         }
     }
 
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(..) = require("darwin-rebuild") {
+            return Err(SkipStep(String::from(
+                "Nix-darwin on macOS must be upgraded via darwin-rebuild switch",
+            ))
+            .into());
+        }
+    }
+
     let run_type = ctx.run_type();
 
     if should_self_upgrade {


### PR DESCRIPTION
[Source](https://github.com/r-darwish/topgrade/pull/967#issue-1292011847)